### PR TITLE
fix: add view to switchLanguage url

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix url to switchLanguage to include the view [Gagaro]
 
 
 2.0.2 (2013-01-13)

--- a/plone/app/i18n/locales/browser/languageselector.pt
+++ b/plone/app/i18n/locales/browser/languageselector.pt
@@ -2,7 +2,7 @@
 <ul id="portal-languageselector"
     tal:define="showFlags view/showFlags;
                 languages view/languages;
-                here_url request/getURL;
+                here_url context/@@plone_context_state/view_url;
                 portal_url view/portal_url;">
     <tal:language repeat="lang languages">
     <li tal:define="code lang/code;


### PR DESCRIPTION
When switching languange from a context with a /view (i.e.: a File), the absolute_url is used to create the url to the switchLanguage script and thus the view is not used.

In the case of a File, this will cause the file to download instead of changing the language. Using request/getURL include the view in the url.
